### PR TITLE
feat: enhance front-end visuals with animations

### DIFF
--- a/src/app/_components/more-stories.tsx
+++ b/src/app/_components/more-stories.tsx
@@ -1,14 +1,15 @@
 import { Post } from "@/interfaces/post";
 import { PostPreview } from "./post-preview";
+import { memo } from "react";
 
 type Props = {
   posts: Post[];
 };
 
-export function MoreStories({ posts }: Props) {
+export const MoreStories = memo(function MoreStories({ posts }: Props) {
   return (
     <section>
-      <h2 className="mb-8 text-5xl md:text-7xl font-bold tracking-tighter leading-tight">
+      <h2 className="mb-8 text-5xl md:text-7xl font-bold tracking-tighter leading-tight bg-gradient-to-r from-cyan-500 to-purple-600 bg-clip-text text-transparent">
         More Stories
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 md:gap-x-16 lg:gap-x-32 gap-y-20 md:gap-y-32 mb-32">
@@ -26,4 +27,4 @@ export function MoreStories({ posts }: Props) {
       </div>
     </section>
   );
-}
+});

--- a/src/app/_components/post-preview.tsx
+++ b/src/app/_components/post-preview.tsx
@@ -22,7 +22,7 @@ export function PostPreview({
   slug,
 }: Props) {
   return (
-    <div>
+    <div className="transition-transform duration-300 hover:scale-[1.02] hover:shadow-md rounded-lg overflow-hidden animate-fadeIn">
       <div className="mb-5">
         <CoverImage slug={slug} title={title} src={coverImage} />
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,25 @@
 import Container from "@/app/_components/container";
 import { HeroPost } from "@/app/_components/hero-post";
 import { Intro } from "@/app/_components/intro";
-import { MoreStories } from "@/app/_components/more-stories";
+import dynamic from "next/dynamic";
 import { getAllPosts } from "@/lib/api";
+
+const MoreStories = dynamic(
+  () => import("@/app/_components/more-stories").then((mod) => mod.MoreStories),
+  {
+    loading: () => (
+      <div className="grid grid-cols-1 md:grid-cols-2 md:gap-x-16 lg:gap-x-32 gap-y-20 md:gap-y-32 mb-32">
+        {Array.from({ length: 2 }).map((_, index) => (
+          <div key={index} className="animate-pulse space-y-4">
+            <div className="h-40 bg-gray-200 rounded" />
+            <div className="h-4 bg-gray-200 rounded w-3/4" />
+            <div className="h-4 bg-gray-200 rounded w-1/2" />
+          </div>
+        ))}
+      </div>
+    ),
+  }
+);
 
 export default function Index() {
   const allPosts = getAllPosts();

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -40,6 +40,15 @@ const config: Config = {
         sm: "0 5px 10px rgba(0, 0, 0, 0.12)",
         md: "0 8px 30px rgba(0, 0, 0, 0.12)",
       },
+      keyframes: {
+        fadeIn: {
+          "0%": { opacity: "0", transform: "translateY(10px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+      },
+      animation: {
+        fadeIn: "fadeIn 0.5s ease-out forwards",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add fade-in animations and hover effects to post previews
- show gradient heading and skeleton loader for More Stories
- define reusable Tailwind animation utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be3e296e6883249b85d426753fe4dd